### PR TITLE
Feature/scalable server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,13 @@ COPY ./tsconfig.json ./
 COPY ./build.sh ./
 RUN npm run build && npm prune --production
 
+FROM deps AS test
+WORKDIR $WORKDIR
+COPY ./test ./test
+COPY ./tsconfig.json ./
+
 FROM base AS app
 WORKDIR $WORKDIR
 COPY --from=build $WORKDIR/node_modules ./node_modules
 COPY --from=build $WORKDIR/dist ./dist
-
 CMD [ "node", "dist/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:14-slim AS base
+ENV WORKDIR=/app
+
+FROM base AS deps
+WORKDIR $WORKDIR
+COPY ./package*.json ./
+RUN npm ci
+
+FROM base AS build
+WORKDIR $WORKDIR
+COPY --from=deps $WORKDIR/node_modules ./node_modules
+COPY ./src ./src
+COPY ./package*.json ./
+COPY ./tsconfig.json ./
+COPY ./build.sh ./
+RUN npm run build && npm prune --production
+
+FROM base AS app
+WORKDIR $WORKDIR
+COPY --from=build $WORKDIR/node_modules ./node_modules
+COPY --from=build $WORKDIR/dist ./dist
+
+CMD [ "node", "dist/index.js" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.4'
+version: '3.8'
 
 networks:
   gmaa-server-network:
@@ -18,6 +18,7 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile
+      target: app
     depends_on:
       - redis_db
     ports:
@@ -27,3 +28,16 @@ services:
       GIPHY_URL: ${GIPHY_URL}
       GIPHY_TOKEN: ${GIPHY_TOKEN}
       REDIS_URL: 'redis://redis_db'
+
+  e2e_test:
+    networks:
+      - gmaa-server-network
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      target: test
+    depends_on:
+      - app
+    environment:
+      APP_URL: 'http://app:8000/api/v1'
+    entrypoint: [ './node_modules/.bin/ts-node', '/app/test/e2e-test.ts' ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+version: '3.4'
+
+networks:
+  gmaa-server-network:
+    driver: bridge
+
+services:
+  redis_db:
+    networks:
+      - gmaa-server-network
+    image: redis:6.2
+    expose:
+      - 6379
+
+  app:
+    networks:
+      - gmaa-server-network
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    depends_on:
+      - redis_db
+    ports:
+      - 8000:8000
+    environment:
+      LOGGER_LEVEL: 'debug'
+      GIPHY_URL: ${GIPHY_URL}
+      GIPHY_TOKEN: ${GIPHY_TOKEN}
+      REDIS_URL: 'redis://redis_db'

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,12 @@
       "integrity": "sha512-zurD1ibz21BRlAOIKP8yhrxlqKx6L9VCwkB5kMiP6nZAhoF5MvC7qS1qPA7nRcr1GJolfkQC7/EAL4hdYejLtg==",
       "dev": true
     },
+    "@types/eventsource": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.5.tgz",
+      "integrity": "sha512-BA9q9uC2PAMkUS7DunHTxWZZaVpeNzDG8lkBxcKwzKJClfDQ4Z59/Csx7HSH/SIqFN2JWh0tAKAM6k/wRR0OZg==",
+      "dev": true
+    },
     "@types/express": {
       "version": "4.17.9",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz",
@@ -872,6 +878,15 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "eventsource": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.0.7.tgz",
+      "integrity": "sha512-4Ln17+vVT0k8aWq+t/bF5arcS3EpT9gYtW66EPacdj/mAFevznsnyoHLPy2BA8gbIQeIHoPsvwmfBftfcG//BQ==",
+      "dev": true,
+      "requires": {
+        "original": "^1.0.0"
+      }
     },
     "express": {
       "version": "4.17.1",
@@ -1743,6 +1758,15 @@
         "fn.name": "1.x.x"
       }
     },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dev": true,
+      "requires": {
+        "url-parse": "^1.4.3"
+      }
+    },
     "p-cancelable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
@@ -1882,6 +1906,12 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -1995,6 +2025,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
       "dev": true
     },
     "responselike": {
@@ -2482,6 +2518,16 @@
         "pupa": "^2.0.1",
         "semver-diff": "^3.1.1",
         "xdg-basedir": "^4.0.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.1.tgz",
+      "integrity": "sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "url-parse-lax": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,15 @@
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA=="
     },
+    "@types/redis": {
+      "version": "2.8.28",
+      "resolved": "https://registry.npmjs.org/@types/redis/-/redis-2.8.28.tgz",
+      "integrity": "sha512-8l2gr2OQ969ypa7hFOeKqtFoY70XkHxISV0pAwmQ2nm6CSPb1brmTmqJCGGrekCo+pAZyWlNXr+Kvo6L/1wijA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/serve-static": {
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.8.tgz",
@@ -736,6 +745,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -1922,6 +1936,35 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "redis": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.0.2.tgz",
+      "integrity": "sha512-PNhLCrjU6vKVuMOyFu7oSP296mwBkcE6lrAjruBYG5LgdSqtRBoVQIylrMyVZD/lkF24RSNNatzvYag6HRBHjQ==",
+      "requires": {
+        "denque": "^1.4.1",
+        "redis-commands": "^1.5.0",
+        "redis-errors": "^1.2.0",
+        "redis-parser": "^3.0.0"
+      }
+    },
+    "redis-commands": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+      "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ=="
+    },
+    "redis-errors": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
+      "integrity": "sha1-62LSrbFeTq9GEMBK/hUpOEJQq60="
+    },
+    "redis-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
+      "integrity": "sha1-tm2CjNyv5rS4pCin3vTGvKwxyLQ=",
+      "requires": {
+        "redis-errors": "^1.0.0"
       }
     },
     "registry-auth-token": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@types/chai": "^4.2.14",
     "@types/cors": "^2.8.9",
+    "@types/eventsource": "^1.1.5",
     "@types/express": "^4.17.9",
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.14",
@@ -31,6 +32,7 @@
     "@types/uuid": "^8.3.0",
     "chai": "^4.2.0",
     "dotenv": "^8.2.0",
+    "eventsource": "^1.0.7",
     "mocha": "^8.2.1",
     "nodemon": "^2.0.6",
     "prettier": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node dist/index.js",
     "dev": "nodemon --exec ts-node src/index.ts",
     "build": "./build.sh",
-    "test": "mocha -r ts-node/register test/*.ts"
+    "test": "mocha -r ts-node/register test/*.ts",
+    "test:e2e": "docker-compose up --build --abort-on-container-exit e2e_test; docker-compose down --volumes --remove-orphans"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/express": "^4.17.9",
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.14",
+    "@types/redis": "^2.8.28",
     "@types/supertest": "^2.0.10",
     "@types/uuid": "^8.3.0",
     "chai": "^4.2.0",
@@ -45,6 +46,7 @@
     "express": "^4.17.1",
     "express-http-context": "^1.2.4",
     "express-requests-logger": "^3.0.2",
+    "redis": "^3.0.2",
     "uuid": "^8.3.2",
     "winston": "^3.3.3"
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ export default Envalid.cleanEnv(
     GIPHY_TOKEN: Envalid.str(),
     GIPHY_LIMIT: Envalid.num({ default: 25 }),
     GIPHY_LANGUAGE: Envalid.str({ default: 'en' }),
+    REDIS_URL: Envalid.url(),
   },
   { strict: true }
 );

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,7 +9,7 @@ export default Envalid.cleanEnv(
     GIPHY_TOKEN: Envalid.str(),
     GIPHY_LIMIT: Envalid.num({ default: 25 }),
     GIPHY_LANGUAGE: Envalid.str({ default: 'en' }),
-    REDIS_URL: Envalid.url(),
+    REDIS_URL: Envalid.str({ default: '' }),
   },
   { strict: true }
 );

--- a/src/controllers/games.ts
+++ b/src/controllers/games.ts
@@ -126,7 +126,7 @@ export const selectImage = ({ notifier, gameService }: Services) => async (
 
   notifier.notifyGameClients(gameCode, Events.PlayerSelectedGif, maybeGame);
 
-  const allSelected = gameService.allPlayersInState(gameCode, PlayerStatus.SELECTED_GIF);
+  const allSelected = await gameService.allPlayersInState(gameCode, PlayerStatus.SELECTED_GIF);
   if (!isErr(allSelected) && allSelected) {
     const game = await gameService.startPresentation(gameCode);
 

--- a/src/controllers/games.ts
+++ b/src/controllers/games.ts
@@ -151,7 +151,7 @@ export const selectImage = ({ notifier, gameService }: Services) => async (
     });
 
     setTimeout(async () => {
-      const g = gameService.startVote(gameCode);
+      const g = await gameService.startVote(gameCode);
       notifier.notifyGameClients(gameCode, Events.RoundStateChanged, g);
     }, imagePresentationDuration * round.images.length);
   }

--- a/src/controllers/games.ts
+++ b/src/controllers/games.ts
@@ -1,10 +1,6 @@
-import { GameService } from '../services/gameService';
-
-import { Events, Game, GameRound, GameRoundStatus, GameStatus, PlayerStatus } from '../types';
 import { Request, Response } from 'express';
-
+import { Events, Game, GameRound, GameRoundStatus, GameStatus, PlayerStatus, Services } from '../types';
 import CAPTIONS_JSON from '../data/captions.json';
-import { ClientNotifier } from '../services/clientNotifier';
 import codeGenerator from '../codeGenerator';
 import { isErr } from '../utils';
 import logger from '../logger';
@@ -42,7 +38,7 @@ const createRounds = (rounds: number): GameRound[] => {
   return gameRounds;
 };
 
-export const createGame = (gameService: GameService) => async (
+export const createGame = ({ gameService }: Services) => async (
   req: Request<{}, any, { rounds: number; players: number }>,
   res: Response
 ) => {
@@ -62,7 +58,7 @@ export const createGame = (gameService: GameService) => async (
   res.json(newGame);
 };
 
-export const getGame = (gameService: GameService) => (req: Request, res: Response) => {
+export const getGame = ({ gameService }: Services) => (req: Request, res: Response) => {
   const code = Number(req.params.code);
   const game = gameService.getGame(code);
   if (game) {
@@ -73,7 +69,7 @@ export const getGame = (gameService: GameService) => (req: Request, res: Respons
   res.sendStatus(404);
 };
 
-export const playerReady = (notifier: ClientNotifier, gameService: GameService) => (
+export const playerReady = ({ notifier, gameService }: Services) => (
   req: Request<{ code: number }, any, { player: string }>,
   res: Response
 ) => {
@@ -97,7 +93,7 @@ export const playerReady = (notifier: ClientNotifier, gameService: GameService) 
   res.sendStatus(200);
 };
 
-export const joinGame = (notifier: ClientNotifier, gameService: GameService) => (req: Request, res: Response) => {
+export const joinGame = ({ notifier, gameService }: Services) => (req: Request, res: Response) => {
   const code = Number(req.params.code);
   const name = req.body.name;
 
@@ -112,7 +108,7 @@ export const joinGame = (notifier: ClientNotifier, gameService: GameService) => 
   res.json(player);
 };
 
-export const selectImage = (notifier: ClientNotifier, gameService: GameService) => (
+export const selectImage = ({ notifier, gameService }: Services) => (
   req: Request<{ code: number; order: number }, any, { player: string; url: string }>,
   res: Response
 ) => {
@@ -159,7 +155,7 @@ export const selectImage = (notifier: ClientNotifier, gameService: GameService) 
   res.json(game);
 };
 
-export const deselectImage = (notifier: ClientNotifier, gameService: GameService) => (
+export const deselectImage = ({ notifier, gameService }: Services) => (
   req: Request<{ code: number; order: number }, any, { player: string; url: string }>,
   res: Response
 ) => {
@@ -188,7 +184,7 @@ export const deselectImage = (notifier: ClientNotifier, gameService: GameService
   return res.sendStatus(200);
 };
 
-export const vote = (notifier: ClientNotifier, gameService: GameService) => (
+export const vote = ({ notifier, gameService }: Services) => (
   req: Request<{ code: string; order: string }, any, { player: string; image: string }>,
   res: Response
 ) => {
@@ -232,7 +228,7 @@ export const vote = (notifier: ClientNotifier, gameService: GameService) => (
   res.json(gameService.getGame(code));
 };
 
-export const gameEvents = (notifier: ClientNotifier, gameService: GameService) => (req: Request, res: Response) => {
+export const gameEvents = ({ notifier, gameService }: Services) => (req: Request, res: Response) => {
   const { code } = req.params;
 
   const gameCode = Number(code);

--- a/src/controllers/games.ts
+++ b/src/controllers/games.ts
@@ -83,7 +83,7 @@ export const playerReady = ({ notifier, gameService }: Services) => async (
   }
   notifier.notifyGameClients(gameCode, Events.PlayerReady, result);
 
-  const allReady = gameService.allPlayersReady(gameCode);
+  const allReady = await gameService.allPlayersReady(gameCode);
   if (!isErr(allReady) && allReady) {
     notifier.notifyGameClients(gameCode, Events.GameReady, await gameService.getGame(gameCode));
     const updatedGame = await gameService.startNewRound(gameCode);

--- a/src/controllers/games.ts
+++ b/src/controllers/games.ts
@@ -1,4 +1,4 @@
-import * as gameService from '../services/gameService';
+import { GameService } from '../services/gameService';
 
 import { Events, Game, GameRound, GameRoundStatus, GameStatus, PlayerStatus } from '../types';
 import { Request, Response } from 'express';
@@ -42,7 +42,10 @@ const createRounds = (rounds: number): GameRound[] => {
   return gameRounds;
 };
 
-export async function createGame(req: Request<{}, any, { rounds: number; players: number }>, res: Response) {
+export const createGame = (gameService: GameService) => async (
+  req: Request<{}, any, { rounds: number; players: number }>,
+  res: Response
+) => {
   const totalRounds = Number(req.body.rounds);
   const totalPlayers = Number(req.body.players);
   const newGame: Game = {
@@ -57,9 +60,9 @@ export async function createGame(req: Request<{}, any, { rounds: number; players
   gameService.addGame(newGame);
 
   res.json(newGame);
-}
+};
 
-export function getGame(req: Request, res: Response) {
+export const getGame = (gameService: GameService) => (req: Request, res: Response) => {
   const code = Number(req.params.code);
   const game = gameService.getGame(code);
   if (game) {
@@ -68,9 +71,9 @@ export function getGame(req: Request, res: Response) {
   }
 
   res.sendStatus(404);
-}
+};
 
-export const playerReady = (notifier: ClientNotifier) => (
+export const playerReady = (notifier: ClientNotifier, gameService: GameService) => (
   req: Request<{ code: number }, any, { player: string }>,
   res: Response
 ) => {
@@ -94,7 +97,7 @@ export const playerReady = (notifier: ClientNotifier) => (
   res.sendStatus(200);
 };
 
-export const joinGame = (notifier: ClientNotifier) => (req: Request, res: Response) => {
+export const joinGame = (notifier: ClientNotifier, gameService: GameService) => (req: Request, res: Response) => {
   const code = Number(req.params.code);
   const name = req.body.name;
 
@@ -109,7 +112,7 @@ export const joinGame = (notifier: ClientNotifier) => (req: Request, res: Respon
   res.json(player);
 };
 
-export const selectImage = (notifier: ClientNotifier) => (
+export const selectImage = (notifier: ClientNotifier, gameService: GameService) => (
   req: Request<{ code: number; order: number }, any, { player: string; url: string }>,
   res: Response
 ) => {
@@ -156,7 +159,7 @@ export const selectImage = (notifier: ClientNotifier) => (
   res.json(game);
 };
 
-export const deselectImage = (notifier: ClientNotifier) => (
+export const deselectImage = (notifier: ClientNotifier, gameService: GameService) => (
   req: Request<{ code: number; order: number }, any, { player: string; url: string }>,
   res: Response
 ) => {
@@ -185,7 +188,7 @@ export const deselectImage = (notifier: ClientNotifier) => (
   return res.sendStatus(200);
 };
 
-export const vote = (notifier: ClientNotifier) => (
+export const vote = (notifier: ClientNotifier, gameService: GameService) => (
   req: Request<{ code: string; order: string }, any, { player: string; image: string }>,
   res: Response
 ) => {
@@ -229,7 +232,7 @@ export const vote = (notifier: ClientNotifier) => (
   res.json(gameService.getGame(code));
 };
 
-export const gameEvents = (notifier: ClientNotifier) => (req: Request, res: Response) => {
+export const gameEvents = (notifier: ClientNotifier, gameService: GameService) => (req: Request, res: Response) => {
   const { code } = req.params;
 
   const gameCode = Number(code);

--- a/src/controllers/games.ts
+++ b/src/controllers/games.ts
@@ -52,6 +52,7 @@ export const createGame = ({ gameService }: Services) => async (
     currentRound: 1,
     totalPlayers,
     rounds: createRounds(totalRounds),
+    revision: 1,
   };
   await gameService.addGame(newGame);
 

--- a/src/controllers/games.ts
+++ b/src/controllers/games.ts
@@ -53,14 +53,14 @@ export const createGame = ({ gameService }: Services) => async (
     totalPlayers,
     rounds: createRounds(totalRounds),
   };
-  gameService.addGame(newGame);
+  await gameService.addGame(newGame);
 
   res.json(newGame);
 };
 
-export const getGame = ({ gameService }: Services) => (req: Request, res: Response) => {
+export const getGame = ({ gameService }: Services) => async (req: Request, res: Response) => {
   const code = Number(req.params.code);
-  const game = gameService.getGame(code);
+  const game = await gameService.getGame(code);
   if (game) {
     res.json(game);
     return;
@@ -69,46 +69,46 @@ export const getGame = ({ gameService }: Services) => (req: Request, res: Respon
   res.sendStatus(404);
 };
 
-export const playerReady = ({ notifier, gameService }: Services) => (
+export const playerReady = ({ notifier, gameService }: Services) => async (
   req: Request<{ code: number }, any, { player: string }>,
   res: Response
 ) => {
   const gameCode = Number(req.params.code);
   const playerId = req.body.player;
 
-  const result = gameService.playerReady(gameCode, playerId);
+  const result = await gameService.playerReady(gameCode, playerId);
 
   if (isErr(result)) {
     return result.error === 'no-such-game' ? res.sendStatus(404) : res.status(400).json({ message: result.error });
   }
-  notifier.notifyGameClients(gameCode, Events.PlayerReady, gameService.getGame(gameCode));
+  notifier.notifyGameClients(gameCode, Events.PlayerReady, result);
 
   const allReady = gameService.allPlayersReady(gameCode);
   if (!isErr(allReady) && allReady) {
-    notifier.notifyGameClients(gameCode, Events.GameReady, gameService.getGame(gameCode));
-    gameService.startNewRound(gameCode);
-    notifier.notifyGameClients(gameCode, Events.RoundStarted, gameService.getGame(gameCode));
+    notifier.notifyGameClients(gameCode, Events.GameReady, await gameService.getGame(gameCode));
+    const updatedGame = await gameService.startNewRound(gameCode);
+    notifier.notifyGameClients(gameCode, Events.RoundStarted, updatedGame);
   }
 
   res.sendStatus(200);
 };
 
-export const joinGame = ({ notifier, gameService }: Services) => (req: Request, res: Response) => {
+export const joinGame = ({ notifier, gameService }: Services) => async (req: Request, res: Response) => {
   const code = Number(req.params.code);
   const name = req.body.name;
 
-  const player = gameService.addPlayer(code, name);
+  const player = await gameService.addPlayer(code, name);
 
   if (isErr(player)) {
     return player.error === 'no-such-game' ? res.sendStatus(404) : res.status(400).json({ message: player.error });
   }
 
-  notifier.notifyGameClients(code, Events.PlayerJoined, gameService.getGame(code));
+  notifier.notifyGameClients(code, Events.PlayerJoined, await gameService.getGame(code));
 
   res.json(player);
 };
 
-export const selectImage = ({ notifier, gameService }: Services) => (
+export const selectImage = ({ notifier, gameService }: Services) => async (
   req: Request<{ code: number; order: number }, any, { player: string; url: string }>,
   res: Response
 ) => {
@@ -116,46 +116,49 @@ export const selectImage = ({ notifier, gameService }: Services) => (
   const gameCode = Number(req.params.code);
   const { player, url } = req.body;
 
-  const result = gameService.selectImage(gameCode, player, url);
-  const game = gameService.getGame(gameCode);
+  const maybeGame = await gameService.selectImage(gameCode, player, url);
 
-  if (isErr(result)) {
-    return result.error === 'no-such-player' ? res.status(400).json({ message: result.error }) : res.sendStatus(404);
-  }
-  if (isErr(game)) {
-    return res.sendStatus(404);
+  if (isErr(maybeGame)) {
+    return maybeGame.error === 'no-such-player'
+      ? res.status(400).json({ message: maybeGame.error })
+      : res.sendStatus(404);
   }
 
-  notifier.notifyGameClients(gameCode, Events.PlayerSelectedGif, game);
+  notifier.notifyGameClients(gameCode, Events.PlayerSelectedGif, maybeGame);
 
   const allSelected = gameService.allPlayersInState(gameCode, PlayerStatus.SELECTED_GIF);
   if (!isErr(allSelected) && allSelected) {
-    gameService.startPresentation(gameCode);
-    notifier.notifyGameClients(gameCode, Events.RoundStateChanged, gameService.getGame(gameCode));
-    const round = game?.rounds.find((r) => r.status === GameRoundStatus.PRESENT);
+    const game = await gameService.startPresentation(gameCode);
+
+    if (isErr(game)) {
+      logger.error({ message: 'Something went wrong when selecting image', gameCode, player, url });
+      return res.sendStatus(500);
+    }
+
+    notifier.notifyGameClients(gameCode, Events.RoundStateChanged, game);
+    const round = game.rounds.find((r) => r.status === GameRoundStatus.PRESENT);
 
     if (!round) {
-      res.json(game);
-      return;
+      return res.json(game);
     }
 
     round.images.forEach((image, idx) => {
-      setTimeout(() => {
-        gameService.setPresentedImage(gameCode, image);
-        notifier.notifyGameClients(gameCode, Events.RoundImagePresented, gameService.getGame(gameCode));
+      setTimeout(async () => {
+        const g = await gameService.setPresentedImage(gameCode, image);
+        notifier.notifyGameClients(gameCode, Events.RoundImagePresented, g);
       }, imagePresentationDuration * idx);
     });
 
-    setTimeout(() => {
-      gameService.startVote(gameCode);
-      notifier.notifyGameClients(gameCode, Events.RoundStateChanged, gameService.getGame(gameCode));
+    setTimeout(async () => {
+      const g = gameService.startVote(gameCode);
+      notifier.notifyGameClients(gameCode, Events.RoundStateChanged, g);
     }, imagePresentationDuration * round.images.length);
   }
 
-  res.json(game);
+  res.json(maybeGame);
 };
 
-export const deselectImage = ({ notifier, gameService }: Services) => (
+export const deselectImage = ({ notifier, gameService }: Services) => async (
   req: Request<{ code: number; order: number }, any, { player: string; url: string }>,
   res: Response
 ) => {
@@ -163,10 +166,10 @@ export const deselectImage = ({ notifier, gameService }: Services) => (
   const roundNumber = Number(req.params.order);
   const { player, url } = req.body;
 
-  const result = gameService.deselectImage(gameCode, roundNumber, player, url);
+  const maybeGame = await gameService.deselectImage(gameCode, roundNumber, player, url);
 
-  if (isErr(result)) {
-    switch (result.error) {
+  if (isErr(maybeGame)) {
+    switch (maybeGame.error) {
       case 'no-such-game':
       case 'no-such-round':
         return res.sendStatus(404);
@@ -175,16 +178,16 @@ export const deselectImage = ({ notifier, gameService }: Services) => (
       case 'bad-round-state':
         return res.sendStatus(500);
       default:
-        throw new Error(`Unhandled error state when deselecting image: ${result.error}`);
+        throw new Error(`Unhandled error state when deselecting image: ${maybeGame.error}`);
     }
   }
 
-  notifier.notifyGameClients(gameCode, Events.PlayerDeselectedGif, gameService.getGame(gameCode));
+  notifier.notifyGameClients(gameCode, Events.PlayerDeselectedGif, maybeGame);
 
   return res.sendStatus(200);
 };
 
-export const vote = ({ notifier, gameService }: Services) => (
+export const vote = ({ notifier, gameService }: Services) => async (
   req: Request<{ code: string; order: string }, any, { player: string; image: string }>,
   res: Response
 ) => {
@@ -192,22 +195,24 @@ export const vote = ({ notifier, gameService }: Services) => (
   const playerId = req.body.player;
   const imageId = req.body.image;
 
-  const result = gameService.vote(code, playerId, imageId);
+  const maybeGame = await gameService.vote(code, playerId, imageId);
 
-  if (isErr(result)) {
-    return result.error === 'no-such-game' ? res.sendStatus(404) : res.status(400).json({ message: result.error });
+  if (isErr(maybeGame)) {
+    return maybeGame.error === 'no-such-game'
+      ? res.sendStatus(404)
+      : res.status(400).json({ message: maybeGame.error });
   }
 
-  notifier.notifyGameClients(code, Events.PlayerVoted, gameService.getGame(code));
+  notifier.notifyGameClients(code, Events.PlayerVoted, maybeGame);
 
-  // TODO: Do we need a timer here as well?
-  if (gameService.allPlayersInState(code, PlayerStatus.VOTED)) {
-    gameService.assignPoints(code);
-    gameService.finishRound(code);
-    notifier.notifyGameClients(code, Events.RoundStateChanged, gameService.getGame(code));
+  const allVoted = await gameService.allPlayersInState(code, PlayerStatus.VOTED);
+  if (!isErr(allVoted) && allVoted) {
+    await gameService.assignPoints(code);
+    const game = await gameService.finishRound(code);
+    notifier.notifyGameClients(code, Events.RoundStateChanged, game);
 
-    setTimeout(() => {
-      const currentGame = gameService.getGame(code);
+    setTimeout(async () => {
+      const currentGame = await gameService.getGame(code);
 
       if (isErr(currentGame)) {
         logger.error({ message: 'Failed to progress after voting', gameCode: code });
@@ -215,24 +220,24 @@ export const vote = ({ notifier, gameService }: Services) => (
       }
 
       if (currentGame && currentGame.currentRound === currentGame.totalRounds) {
-        gameService.finishGame(code);
-        notifier.notifyGameClients(code, Events.GameFinished, gameService.getGame(code));
+        const g = await gameService.finishGame(code);
+        notifier.notifyGameClients(code, Events.GameFinished, g);
       } else {
-        gameService.nextRound(code);
-        gameService.startImageSelection(code);
-        notifier.notifyGameClients(code, Events.RoundStarted, gameService.getGame(code));
+        await gameService.nextRound(code);
+        const g = await gameService.startImageSelection(code);
+        notifier.notifyGameClients(code, Events.RoundStarted, g);
       }
     }, 10 * 1000);
   }
 
-  res.json(gameService.getGame(code));
+  res.json(maybeGame);
 };
 
-export const gameEvents = ({ notifier, gameService }: Services) => (req: Request, res: Response) => {
+export const gameEvents = ({ notifier, gameService }: Services) => async (req: Request, res: Response) => {
   const { code } = req.params;
 
   const gameCode = Number(code);
-  const game = gameService.getGame(gameCode);
+  const game = await gameService.getGame(gameCode);
 
   if (isErr(game)) {
     res.status(404).json({ message: `No game exists with code ${gameCode}` });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { requestLogger } from './middleware/requestLogger';
 import { ClientNotifier } from './services/clientNotifier';
 import { GameService } from './services/gameService';
 import { Services } from './types';
-import { InMemoryGameDb } from './services/db';
+import { InMemoryGameDb, RedisGameDb } from './services/db';
 
 const app = express();
 
@@ -34,9 +34,11 @@ app.get('/api-spec', (_req, res) => {
   res.sendFile(path.resolve(__dirname, './api-spec.yaml'));
 });
 
+const db = config.REDIS_URL ? new RedisGameDb() : new InMemoryGameDb();
+
 const services: Services = {
   notifier: new ClientNotifier(),
-  gameService: new GameService(new InMemoryGameDb()),
+  gameService: new GameService(db),
 };
 
 app.use('/api/v1/games', GamesRouter(services));

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { requestLogger } from './middleware/requestLogger';
 import { ClientNotifier } from './services/clientNotifier';
 import { GameService } from './services/gameService';
 import { Services } from './types';
+import { GameDb } from './services/db';
 
 const app = express();
 
@@ -35,7 +36,7 @@ app.get('/api-spec', (_req, res) => {
 
 const services: Services = {
   notifier: new ClientNotifier(),
-  gameService: new GameService(),
+  gameService: new GameService(new GameDb()),
 };
 
 app.use('/api/v1/games', GamesRouter(services));

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import httpContext from 'express-http-context';
 import { requestContext } from './middleware/requestContext';
 import { requestLogger } from './middleware/requestLogger';
 import { ClientNotifier } from './services/clientNotifier';
+import { GameService } from './services/gameService';
 
 const app = express();
 
@@ -32,8 +33,9 @@ app.get('/api-spec', (_req, res) => {
 });
 
 const notifier = new ClientNotifier();
+const gameService = new GameService();
 
-app.use('/api/v1/games', GamesRouter(notifier));
+app.use('/api/v1/games', GamesRouter(notifier, gameService));
 app.use('/api/v1/gifs', GifsRouter());
 
 app.use(errorHandler());

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { requestContext } from './middleware/requestContext';
 import { requestLogger } from './middleware/requestLogger';
 import { ClientNotifier } from './services/clientNotifier';
 import { GameService } from './services/gameService';
+import { Services } from './types';
 
 const app = express();
 
@@ -32,10 +33,12 @@ app.get('/api-spec', (_req, res) => {
   res.sendFile(path.resolve(__dirname, './api-spec.yaml'));
 });
 
-const notifier = new ClientNotifier();
-const gameService = new GameService();
+const services: Services = {
+  notifier: new ClientNotifier(),
+  gameService: new GameService(),
+};
 
-app.use('/api/v1/games', GamesRouter(notifier, gameService));
+app.use('/api/v1/games', GamesRouter(services));
 app.use('/api/v1/gifs', GifsRouter());
 
 app.use(errorHandler());

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import { requestLogger } from './middleware/requestLogger';
 import { ClientNotifier } from './services/clientNotifier';
 import { GameService } from './services/gameService';
 import { Services } from './types';
-import { GameDb } from './services/db';
+import { InMemoryGameDb } from './services/db';
 
 const app = express();
 
@@ -36,7 +36,7 @@ app.get('/api-spec', (_req, res) => {
 
 const services: Services = {
   notifier: new ClientNotifier(),
-  gameService: new GameService(new GameDb()),
+  gameService: new GameService(new InMemoryGameDb()),
 };
 
 app.use('/api/v1/games', GamesRouter(services));

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,4 +38,13 @@ app.use('/api/v1/gifs', GifsRouter());
 
 app.use(errorHandler());
 
+const cleanup = () => {
+  logger.info({ message: 'Server cleanup finished' });
+  process.exit(0);
+};
+
+// Ensures Docker can shutdown the process correctly
+process.on('SIGINT', cleanup);
+process.on('SIGTERM', cleanup);
+
 app.listen(config.PORT, () => logger.info({ message: `Running on ${config.PORT}!` }));

--- a/src/routers/games.ts
+++ b/src/routers/games.ts
@@ -10,20 +10,19 @@ import {
   deselectImage,
   vote,
 } from './../controllers/games';
-import { ClientNotifier } from '../services/clientNotifier';
-import { GameService } from '../services/gameService';
+import { Services } from '../types';
 
-export default function GamesRouter(notifier: ClientNotifier, gameService: GameService) {
+export default function GamesRouter(services: Services) {
   const router = Router();
-  router.post('/', handlerWrapper(createGame(gameService)));
-  router.get('/:code', handlerWrapper(getGame(gameService)));
-  router.post('/:code/join', handlerWrapper(joinGame(notifier, gameService)));
-  router.post('/:code/ready', handlerWrapper(playerReady(notifier, gameService)));
+  router.post('/', handlerWrapper(createGame(services)));
+  router.get('/:code', handlerWrapper(getGame(services)));
+  router.post('/:code/join', handlerWrapper(joinGame(services)));
+  router.post('/:code/ready', handlerWrapper(playerReady(services)));
   router.post('/:code/rounds/:order/done', NotImplemented);
-  router.post('/:code/rounds/:order/images', handlerWrapper(selectImage(notifier, gameService)));
-  router.post('/:code/rounds/:order/images/deselect', handlerWrapper(deselectImage(notifier, gameService)));
-  router.post('/:code/rounds/:order/vote', handlerWrapper(vote(notifier, gameService)));
-  router.get('/:code/events', handlerWrapper(gameEvents(notifier, gameService)));
+  router.post('/:code/rounds/:order/images', handlerWrapper(selectImage(services)));
+  router.post('/:code/rounds/:order/images/deselect', handlerWrapper(deselectImage(services)));
+  router.post('/:code/rounds/:order/vote', handlerWrapper(vote(services)));
+  router.get('/:code/events', handlerWrapper(gameEvents(services)));
   return router;
 }
 

--- a/src/routers/games.ts
+++ b/src/routers/games.ts
@@ -11,18 +11,19 @@ import {
   vote,
 } from './../controllers/games';
 import { ClientNotifier } from '../services/clientNotifier';
+import { GameService } from '../services/gameService';
 
-export default function GamesRouter(notifier: ClientNotifier) {
+export default function GamesRouter(notifier: ClientNotifier, gameService: GameService) {
   const router = Router();
-  router.post('/', handlerWrapper(createGame));
-  router.get('/:code', handlerWrapper(getGame));
-  router.post('/:code/join', handlerWrapper(joinGame(notifier)));
-  router.post('/:code/ready', handlerWrapper(playerReady(notifier)));
+  router.post('/', handlerWrapper(createGame(gameService)));
+  router.get('/:code', handlerWrapper(getGame(gameService)));
+  router.post('/:code/join', handlerWrapper(joinGame(notifier, gameService)));
+  router.post('/:code/ready', handlerWrapper(playerReady(notifier, gameService)));
   router.post('/:code/rounds/:order/done', NotImplemented);
-  router.post('/:code/rounds/:order/images', handlerWrapper(selectImage(notifier)));
-  router.post('/:code/rounds/:order/images/deselect', handlerWrapper(deselectImage(notifier)));
-  router.post('/:code/rounds/:order/vote', handlerWrapper(vote(notifier)));
-  router.get('/:code/events', handlerWrapper(gameEvents(notifier)));
+  router.post('/:code/rounds/:order/images', handlerWrapper(selectImage(notifier, gameService)));
+  router.post('/:code/rounds/:order/images/deselect', handlerWrapper(deselectImage(notifier, gameService)));
+  router.post('/:code/rounds/:order/vote', handlerWrapper(vote(notifier, gameService)));
+  router.get('/:code/events', handlerWrapper(gameEvents(notifier, gameService)));
   return router;
 }
 

--- a/src/services/clientNotifier.ts
+++ b/src/services/clientNotifier.ts
@@ -1,5 +1,8 @@
+import { EventEmitter } from 'events';
 import { Response } from 'express';
+import { createClient, RedisClient } from 'redis';
 import { v4 as uuidv4 } from 'uuid';
+import config from '../config';
 import logger from '../logger';
 import { Events } from '../types';
 
@@ -9,11 +12,84 @@ interface Client {
   res: Response;
 }
 
+interface PubSub {
+  onMessage: (cb: (gameCode: number, eventName: Events, data: any) => void) => void;
+  publishMessage: (gameCode: number, eventName: Events, data: any) => void;
+}
+
+class EventPubSub implements PubSub {
+  private emitter: EventEmitter;
+
+  constructor() {
+    this.emitter = new EventEmitter();
+  }
+
+  onMessage = (cb: (gameCode: number, eventName: Events, data: any) => void) => {
+    this.emitter.on('message', cb);
+  };
+
+  publishMessage = (gameCode: number, eventName: Events, data: any) => {
+    this.emitter.emit('message', gameCode, eventName, data);
+  };
+}
+
+class RedisPubSub implements PubSub {
+  private channel = 'gmaa-game-events';
+  private subscriber: RedisClient;
+  private publisher: RedisClient;
+
+  constructor(url: string) {
+    this.publisher = createClient(url);
+    this.subscriber = createClient(url);
+    this.subscriber.subscribe(this.channel);
+  }
+
+  onMessage = (cb: (gameCode: number, eventName: Events, data: any) => void) => {
+    this.subscriber.on('message', (_channel, message) => {
+      const { gameCode, eventName, data } = JSON.parse(message) as { gameCode: number; eventName: Events; data: any };
+
+      cb(gameCode, eventName, data);
+    });
+  };
+
+  publishMessage = (gameCode: number, eventName: Events, data: any) => {
+    this.publisher.publish(this.channel, JSON.stringify({ gameCode, eventName, data }));
+  };
+}
+
 export class ClientNotifier {
   private clients: Client[];
+  private subscriber: PubSub;
+  private publisher: PubSub;
 
   constructor() {
     this.clients = [];
+
+    if (config.REDIS_URL) {
+      logger.info({ message: 'Initializing ClientNotifier with RedisPubSub' });
+
+      this.subscriber = new RedisPubSub(config.REDIS_URL);
+      this.publisher = new RedisPubSub(config.REDIS_URL);
+    } else {
+      logger.info({ message: 'Initializing ClientNotifier with EventPubSub' });
+
+      const pubSub = new EventPubSub();
+      this.subscriber = pubSub;
+      this.publisher = pubSub;
+    }
+
+    this.subscriber.onMessage((gameCode, eventName, data) => {
+      const players = this.clients.filter((c) => c.gameCode === gameCode);
+
+      const payload = {
+        event: eventName,
+        data,
+      };
+
+      players.forEach((p) => {
+        p.res.write(`data: ${JSON.stringify(payload)}\n\n`);
+      });
+    });
   }
 
   addClient(gameCode: number, res: Response): string {
@@ -45,15 +121,6 @@ export class ClientNotifier {
   }
 
   notifyGameClients<T>(gameCode: number, eventName: Events, data: Exclude<T, Promise<any>>) {
-    const players = this.clients.filter((c) => c.gameCode === gameCode);
-
-    const payload = {
-      event: eventName,
-      data,
-    };
-
-    players.forEach((p) => {
-      p.res.write(`data: ${JSON.stringify(payload)}\n\n`);
-    });
+    this.publisher.publishMessage(gameCode, eventName, data);
   }
 }

--- a/src/services/clientNotifier.ts
+++ b/src/services/clientNotifier.ts
@@ -44,7 +44,7 @@ export class ClientNotifier {
     });
   }
 
-  notifyGameClients<T>(gameCode: number, eventName: Events, data: T) {
+  notifyGameClients<T>(gameCode: number, eventName: Events, data: Exclude<T, Promise<any>>) {
     const players = this.clients.filter((c) => c.gameCode === gameCode);
 
     const payload = {

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -22,9 +22,10 @@ export class InMemoryGameDb implements GameDb {
   }
 
   setGame(game: Game) {
-    this.games[game.code] = game;
+    const g = { ...game, revision: game.revision + 1 };
+    this.games[game.code] = g;
 
-    return Promise.resolve(game);
+    return Promise.resolve(g);
   }
 
   exists(code: number) {
@@ -61,12 +62,13 @@ export class RedisGameDb implements GameDb {
 
   setGame(game: Game): Promise<Game> {
     return new Promise((resolve, reject) => {
-      this.client.set(`${this.prefix}:${game.code}`, JSON.stringify(game), 'EX', this.gameTtlSec, (err, _result) => {
+      const g = { ...game, revision: game.revision + 1 };
+      this.client.set(`${this.prefix}:${game.code}`, JSON.stringify(g), 'EX', this.gameTtlSec, (err, _result) => {
         if (err) {
           return reject(err);
         }
 
-        resolve(game);
+        resolve(g);
       });
     });
   }

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,0 +1,41 @@
+import redis, { RedisClient } from 'redis';
+import config from '../config';
+import { Game } from '../types';
+
+export class GameDb {
+  private client: RedisClient;
+  private prefix = 'gmaa-game';
+  private gameTtlSec = 30 * 60;
+
+  constructor() {
+    this.client = redis.createClient(config.REDIS_URL);
+  }
+
+  getGame(code: number): Promise<Game | null> {
+    return new Promise((resolve, reject) => {
+      this.client.get(`${this.prefix}:${code}`, (err, result) => {
+        if (err) {
+          return reject(err);
+        }
+
+        if (!result) {
+          return resolve(null);
+        }
+
+        resolve(JSON.parse(result) as Game);
+      });
+    });
+  }
+
+  setGame(game: Game): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.client.set(`${this.prefix}:${game.code}`, JSON.stringify(game), 'EX', this.gameTtlSec, (err, _result) => {
+        if (err) {
+          return reject(err);
+        }
+
+        resolve();
+      });
+    });
+  }
+}

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -2,7 +2,32 @@ import redis, { RedisClient } from 'redis';
 import config from '../config';
 import { Game } from '../types';
 
-export class GameDb {
+export interface GameDb {
+  getGame(code: number): Promise<Game | null>;
+  setGame(game: Game): Promise<void>;
+}
+
+export class InMemoryGameDb implements GameDb {
+  private games: { [code: number]: Game };
+
+  constructor() {
+    this.games = {};
+  }
+
+  getGame(code: number) {
+    const game = this.games[code];
+
+    return Promise.resolve(game ? game : null);
+  }
+
+  setGame(game: Game) {
+    this.games[game.code] = game;
+
+    return Promise.resolve();
+  }
+}
+
+export class RedisGameDb implements GameDb {
   private client: RedisClient;
   private prefix = 'gmaa-game';
   private gameTtlSec = 30 * 60;

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,5 +1,6 @@
 import redis, { RedisClient } from 'redis';
 import config from '../config';
+import logger from '../logger';
 import { Game } from '../types';
 
 export interface GameDb {
@@ -12,6 +13,7 @@ export class InMemoryGameDb implements GameDb {
   private games: { [code: number]: Game };
 
   constructor() {
+    logger.info({ message: 'Initializing InMemoryGameDb...' });
     this.games = {};
   }
 
@@ -41,6 +43,7 @@ export class RedisGameDb implements GameDb {
   private gameTtlSec = 30 * 60;
 
   constructor() {
+    logger.info({ message: 'Initilizing RedisGameDb...' });
     this.client = redis.createClient(config.REDIS_URL);
   }
 

--- a/src/services/gameService.ts
+++ b/src/services/gameService.ts
@@ -2,6 +2,7 @@ import { Game, GameRound, GameRoundStatus, GameStatus, Image, Player, PlayerStat
 
 import { v4 as uuidv4 } from 'uuid';
 import { isErr, Result as R } from '../utils';
+import { GameDb } from './db';
 
 type GameServiceErrors =
   | 'no-such-game'
@@ -20,9 +21,11 @@ type Result<T, E extends GameServiceErrors> = R<T, E>;
 
 export class GameService {
   private GAMES: { [code: number]: Game };
+  private db: GameDb;
 
-  constructor() {
+  constructor(db: GameDb) {
     this.GAMES = {};
+    this.db = db;
   }
 
   getGame(code: number): Result<Game, 'no-such-game'> {

--- a/src/services/gameService.ts
+++ b/src/services/gameService.ts
@@ -18,313 +18,315 @@ type GameServiceErrors =
 
 type Result<T, E extends GameServiceErrors> = R<T, E>;
 
-interface GameService {
-  [code: number]: Game;
-}
+export class GameService {
+  private GAMES: { [code: number]: Game };
 
-const GAMES: GameService = {};
-
-export function getGame(code: number): Result<Game, 'no-such-game'> {
-  const game = GAMES[code];
-
-  return game ? game : { error: 'no-such-game' };
-}
-
-export function addGame(game: Game): Result<void, 'game-exists'> {
-  if (game.code in GAMES) {
-    return { error: 'game-exists' };
+  constructor() {
+    this.GAMES = {};
   }
 
-  GAMES[game.code] = game;
-}
+  getGame(code: number): Result<Game, 'no-such-game'> {
+    const game = this.GAMES[code];
 
-export function addPlayer(code: number, name: string): Result<Player, 'no-such-game' | 'player-exists'> {
-  const maybeGame = getGame(code);
-
-  if (isErr(maybeGame)) {
-    return maybeGame;
+    return game ? game : { error: 'no-such-game' };
   }
 
-  if (maybeGame.players.some((p) => p.name === name)) {
-    return { error: 'player-exists' };
+  addGame(game: Game): Result<void, 'game-exists'> {
+    if (game.code in this.GAMES) {
+      return { error: 'game-exists' };
+    }
+
+    this.GAMES[game.code] = game;
   }
 
-  const player: Player = {
-    id: uuidv4(),
-    name,
-    status: PlayerStatus.JOINED,
-    points: 0,
-  };
+  addPlayer(code: number, name: string): Result<Player, 'no-such-game' | 'player-exists'> {
+    const maybeGame = this.getGame(code);
 
-  const players = [...maybeGame.players, player];
-  GAMES[code] = { ...maybeGame, players };
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
 
-  return player;
-}
+    if (maybeGame.players.some((p) => p.name === name)) {
+      return { error: 'player-exists' };
+    }
 
-export function playerReady(code: number, playerId: string): Result<void, 'no-such-game' | 'no-such-player'> {
-  const maybeGame = getGame(code);
+    const player: Player = {
+      id: uuidv4(),
+      name,
+      status: PlayerStatus.JOINED,
+      points: 0,
+    };
 
-  if (isErr(maybeGame)) {
-    return maybeGame;
+    const players = [...maybeGame.players, player];
+    this.GAMES[code] = { ...maybeGame, players };
+
+    return player;
   }
 
-  const player = maybeGame.players.find((p) => p.id === playerId);
+  playerReady(code: number, playerId: string): Result<void, 'no-such-game' | 'no-such-player'> {
+    const maybeGame = this.getGame(code);
 
-  if (!player) {
-    return { error: 'no-such-player' };
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
+
+    const player = maybeGame.players.find((p) => p.id === playerId);
+
+    if (!player) {
+      return { error: 'no-such-player' };
+    }
+
+    player.status = PlayerStatus.READY;
   }
 
-  player.status = PlayerStatus.READY;
-}
+  allPlayersInState(code: number, state: PlayerStatus): Result<boolean, 'no-such-game'> {
+    const maybeGame = this.getGame(code);
 
-export function allPlayersInState(code: number, state: PlayerStatus): Result<boolean, 'no-such-game'> {
-  const maybeGame = getGame(code);
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
 
-  if (isErr(maybeGame)) {
-    return maybeGame;
+    return maybeGame.players.every((p) => p.status === state);
   }
 
-  return maybeGame.players.every((p) => p.status === state);
-}
+  allPlayersReady(code: number): Result<boolean, 'no-such-game'> {
+    const maybeGame = this.getGame(code);
 
-export function allPlayersReady(code: number): Result<boolean, 'no-such-game'> {
-  const maybeGame = getGame(code);
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
 
-  if (isErr(maybeGame)) {
-    return maybeGame;
+    if (maybeGame.totalPlayers !== maybeGame.players.length) {
+      return false;
+    }
+
+    return this.allPlayersInState(code, PlayerStatus.READY);
   }
 
-  if (maybeGame.totalPlayers !== maybeGame.players.length) {
-    return false;
+  selectImage(
+    code: number,
+    playerId: string,
+    imageUrl: string
+  ): Result<void, 'no-such-game' | 'no-such-round' | 'no-such-player'> {
+    const maybeGame = this.getGame(code);
+
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
+
+    const player = maybeGame.players.find((p) => p.id === playerId);
+    if (!player) {
+      return { error: 'no-such-player' };
+    }
+    player.status = PlayerStatus.SELECTED_GIF;
+
+    const round = maybeGame.rounds.find((r) => r.status === GameRoundStatus.SELECT_GIF);
+
+    if (!round) {
+      return { error: 'no-such-round' };
+    }
+
+    round.images = round.images
+      .filter((i) => i.playerId !== playerId) // replace any image previously selected by the player
+      .concat({
+        id: Buffer.from(imageUrl).toString('base64'),
+        url: imageUrl,
+        playerId,
+        votes: 0,
+      });
   }
 
-  return allPlayersInState(code, PlayerStatus.READY);
-}
+  startNewRound(code: number): Result<void, 'no-such-game' | 'in-active-round' | 'no-remaining-rounds'> {
+    const maybeGame = this.getGame(code);
 
-export function selectImage(
-  code: number,
-  playerId: string,
-  imageUrl: string
-): Result<void, 'no-such-game' | 'no-such-round' | 'no-such-player'> {
-  const maybeGame = getGame(code);
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
+    if (!maybeGame.rounds.some((r) => r.status === GameRoundStatus.NOT_STARTED)) {
+      return { error: 'no-remaining-rounds' };
+    }
+    if (maybeGame.rounds.some((r) => ![GameRoundStatus.NOT_STARTED, GameRoundStatus.FINSIHED].includes(r.status))) {
+      return { error: 'in-active-round' };
+    }
 
-  if (isErr(maybeGame)) {
-    return maybeGame;
+    this.startImageSelection(code);
   }
 
-  const player = maybeGame.players.find((p) => p.id === playerId);
-  if (!player) {
-    return { error: 'no-such-player' };
-  }
-  player.status = PlayerStatus.SELECTED_GIF;
+  private changeGameRoundStatus(
+    code: number,
+    from: GameRoundStatus,
+    to: GameRoundStatus
+  ): Result<void, 'no-such-game' | 'bad-round-state'> {
+    const maybeGame = this.getGame(code);
 
-  const round = maybeGame.rounds.find((r) => r.status === GameRoundStatus.SELECT_GIF);
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
 
-  if (!round) {
-    return { error: 'no-such-round' };
-  }
+    const round = maybeGame.rounds.find((r) => r.status === from);
 
-  round.images = round.images
-    .filter((i) => i.playerId !== playerId) // replace any image previously selected by the player
-    .concat({
-      id: Buffer.from(imageUrl).toString('base64'),
-      url: imageUrl,
-      playerId,
-      votes: 0,
-    });
-}
+    if (!round) {
+      return { error: 'bad-round-state' };
+    }
 
-export function startNewRound(code: number): Result<void, 'no-such-game' | 'in-active-round' | 'no-remaining-rounds'> {
-  const maybeGame = getGame(code);
-
-  if (isErr(maybeGame)) {
-    return maybeGame;
-  }
-  if (!maybeGame.rounds.some((r) => r.status === GameRoundStatus.NOT_STARTED)) {
-    return { error: 'no-remaining-rounds' };
-  }
-  if (maybeGame.rounds.some((r) => ![GameRoundStatus.NOT_STARTED, GameRoundStatus.FINSIHED].includes(r.status))) {
-    return { error: 'in-active-round' };
+    round.status = to;
   }
 
-  startImageSelection(code);
-}
-
-function changeGameRoundStatus(
-  code: number,
-  from: GameRoundStatus,
-  to: GameRoundStatus
-): Result<void, 'no-such-game' | 'bad-round-state'> {
-  const maybeGame = getGame(code);
-
-  if (isErr(maybeGame)) {
-    return maybeGame;
+  startImageSelection(code: number) {
+    return this.changeGameRoundStatus(code, GameRoundStatus.NOT_STARTED, GameRoundStatus.SELECT_GIF);
   }
 
-  const round = maybeGame.rounds.find((r) => r.status === from);
-
-  if (!round) {
-    return { error: 'bad-round-state' };
+  startVote(code: number) {
+    return this.changeGameRoundStatus(code, GameRoundStatus.PRESENT, GameRoundStatus.VOTE);
   }
 
-  round.status = to;
-}
-
-export function startImageSelection(code: number) {
-  return changeGameRoundStatus(code, GameRoundStatus.NOT_STARTED, GameRoundStatus.SELECT_GIF);
-}
-
-export function startVote(code: number) {
-  return changeGameRoundStatus(code, GameRoundStatus.PRESENT, GameRoundStatus.VOTE);
-}
-
-export function startPresentation(code: number) {
-  return changeGameRoundStatus(code, GameRoundStatus.SELECT_GIF, GameRoundStatus.PRESENT);
-}
-
-export function finishRound(code: number) {
-  return changeGameRoundStatus(code, GameRoundStatus.VOTE, GameRoundStatus.FINSIHED);
-}
-
-export function vote(
-  code: number,
-  playerId: string,
-  imageId: string
-): Result<
-  void,
-  'no-such-game' | 'bad-round-state' | 'no-such-image' | 'no-such-player' | 'own-image' | 'already-voted'
-> {
-  const maybeGame = getGame(code);
-
-  if (isErr(maybeGame)) {
-    return maybeGame;
+  startPresentation(code: number) {
+    return this.changeGameRoundStatus(code, GameRoundStatus.SELECT_GIF, GameRoundStatus.PRESENT);
   }
 
-  const round = maybeGame.rounds.find((r) => r.status === GameRoundStatus.VOTE);
-
-  if (!round) {
-    return { error: 'bad-round-state' };
+  finishRound(code: number) {
+    return this.changeGameRoundStatus(code, GameRoundStatus.VOTE, GameRoundStatus.FINSIHED);
   }
 
-  const image = round.images.find((img) => img.id === imageId);
-  const player = maybeGame.players.find((p) => p.id === playerId);
+  vote(
+    code: number,
+    playerId: string,
+    imageId: string
+  ): Result<
+    void,
+    'no-such-game' | 'bad-round-state' | 'no-such-image' | 'no-such-player' | 'own-image' | 'already-voted'
+  > {
+    const maybeGame = this.getGame(code);
 
-  if (!image) {
-    return { error: 'no-such-image' };
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
+
+    const round = maybeGame.rounds.find((r) => r.status === GameRoundStatus.VOTE);
+
+    if (!round) {
+      return { error: 'bad-round-state' };
+    }
+
+    const image = round.images.find((img) => img.id === imageId);
+    const player = maybeGame.players.find((p) => p.id === playerId);
+
+    if (!image) {
+      return { error: 'no-such-image' };
+    }
+    if (!player) {
+      return { error: 'no-such-player' };
+    }
+    if (player.status === PlayerStatus.VOTED) {
+      return { error: 'already-voted' };
+    }
+    if (image.playerId === playerId) {
+      return { error: 'own-image' };
+    }
+
+    image.votes += 1;
+    player.status = PlayerStatus.VOTED;
   }
-  if (!player) {
-    return { error: 'no-such-player' };
-  }
-  if (player.status === PlayerStatus.VOTED) {
-    return { error: 'already-voted' };
-  }
-  if (image.playerId === playerId) {
-    return { error: 'own-image' };
-  }
 
-  image.votes += 1;
-  player.status = PlayerStatus.VOTED;
-}
+  assignPoints(code: number): Result<void, 'no-such-game' | 'bad-round-state'> {
+    const maybeGame = this.getGame(code);
 
-export function assignPoints(code: number): Result<void, 'no-such-game' | 'bad-round-state'> {
-  const maybeGame = getGame(code);
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
 
-  if (isErr(maybeGame)) {
-    return maybeGame;
-  }
+    const round = maybeGame.rounds.find((item) => item.status === GameRoundStatus.VOTE);
 
-  const round = maybeGame.rounds.find((item) => item.status === GameRoundStatus.VOTE);
+    if (!round) {
+      return { error: 'bad-round-state' };
+    }
 
-  if (!round) {
-    return { error: 'bad-round-state' };
-  }
-
-  for (const image of round.images) {
-    const player = maybeGame.players.find((item) => item.id === image.playerId);
-    if (player) {
-      player.points += image.votes;
+    for (const image of round.images) {
+      const player = maybeGame.players.find((item) => item.id === image.playerId);
+      if (player) {
+        player.points += image.votes;
+      }
     }
   }
-}
 
-export function setPresentedImage(code: number, image: Image): Result<void, 'no-such-game' | 'bad-round-state'> {
-  const maybeGame = getGame(code);
+  setPresentedImage(code: number, image: Image): Result<void, 'no-such-game' | 'bad-round-state'> {
+    const maybeGame = this.getGame(code);
 
-  if (isErr(maybeGame)) {
-    return maybeGame;
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
+
+    const round = maybeGame.rounds.find((r) => r.status === GameRoundStatus.PRESENT);
+
+    if (!round) {
+      return { error: 'bad-round-state' };
+    }
+
+    round.presentImage = image.url;
   }
 
-  const round = maybeGame.rounds.find((r) => r.status === GameRoundStatus.PRESENT);
+  finishGame(code: number): Result<void, 'no-such-game'> {
+    const maybeGame = this.getGame(code);
 
-  if (!round) {
-    return { error: 'bad-round-state' };
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
+
+    maybeGame.status = GameStatus.FINISHED;
   }
 
-  round.presentImage = image.url;
-}
+  nextRound(code: number): Result<void, 'no-such-game' | 'no-such-round'> {
+    const maybeGame = this.getGame(code);
 
-export function finishGame(code: number): Result<void, 'no-such-game'> {
-  const maybeGame = getGame(code);
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
 
-  if (isErr(maybeGame)) {
-    return maybeGame;
+    if (maybeGame.currentRound >= maybeGame.totalRounds) {
+      return { error: 'no-such-round' };
+    }
+
+    maybeGame.currentRound += 1;
   }
 
-  maybeGame.status = GameStatus.FINISHED;
-}
+  getRound(code: number, roundNumber: number): Result<GameRound, 'no-such-game' | 'no-such-round'> {
+    const maybeGame = this.getGame(code);
 
-export function nextRound(code: number): Result<void, 'no-such-game' | 'no-such-round'> {
-  const maybeGame = getGame(code);
+    if (isErr(maybeGame)) {
+      return maybeGame;
+    }
 
-  if (isErr(maybeGame)) {
-    return maybeGame;
-  }
+    const round = maybeGame.rounds.find((r) => r.order === roundNumber);
 
-  if (maybeGame.currentRound >= maybeGame.totalRounds) {
-    return { error: 'no-such-round' };
-  }
+    if (!round) {
+      return { error: 'no-such-round' };
+    }
 
-  maybeGame.currentRound += 1;
-}
-
-export function getRound(code: number, roundNumber: number): Result<GameRound, 'no-such-game' | 'no-such-round'> {
-  const maybeGame = getGame(code);
-
-  if (isErr(maybeGame)) {
-    return maybeGame;
-  }
-
-  const round = maybeGame.rounds.find((r) => r.order === roundNumber);
-
-  if (!round) {
-    return { error: 'no-such-round' };
-  }
-
-  return round;
-}
-
-export function deselectImage(
-  code: number,
-  roundNumber: number,
-  playerId: string,
-  imageUrl: string
-): Result<void, 'no-such-game' | 'no-such-round' | 'no-such-image' | 'bad-round-state'> {
-  const round = getRound(code, roundNumber);
-
-  if (isErr(round)) {
     return round;
   }
 
-  if (round.status !== GameRoundStatus.SELECT_GIF) {
-    return { error: 'bad-round-state' };
+  deselectImage(
+    code: number,
+    roundNumber: number,
+    playerId: string,
+    imageUrl: string
+  ): Result<void, 'no-such-game' | 'no-such-round' | 'no-such-image' | 'bad-round-state'> {
+    const round = this.getRound(code, roundNumber);
+
+    if (isErr(round)) {
+      return round;
+    }
+
+    if (round.status !== GameRoundStatus.SELECT_GIF) {
+      return { error: 'bad-round-state' };
+    }
+
+    const image = round.images.find((item) => item.playerId === playerId);
+
+    if (!image || image.url !== imageUrl) {
+      return { error: 'no-such-image' };
+    }
+
+    round.images = round.images.filter(({ id }) => id !== image.id);
   }
-
-  const image = round.images.find((item) => item.playerId === playerId);
-
-  if (!image || image.url !== imageUrl) {
-    return { error: 'no-such-image' };
-  }
-
-  round.images = round.images.filter(({ id }) => id !== image.id);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export interface Game {
   currentRound: number;
   totalPlayers: number;
   rounds: GameRound[];
+  revision: number;
 }
 
 export enum GameRoundStatus {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+import { ClientNotifier } from './services/clientNotifier';
+import { GameService } from './services/gameService';
+
 export enum GameStatus {
   ACTIVE = 'ACTIVE',
   FINISHED = 'FINISHED',
@@ -65,4 +68,9 @@ export enum Events {
   RoundStarted = 'roundstarted',
   RoundStateChanged = 'roundstatechanged',
   RoundImagePresented = 'roundimagepresented',
+}
+
+export interface Services {
+  gameService: GameService;
+  notifier: ClientNotifier;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,6 @@ export interface Err<E> {
   error: E;
 }
 
-export const isErr = <T, E>(result: Result<T, E>): result is Err<E> => {
+export const isErr = <T, E>(result: Result<Exclude<T, Promise<any>>, E>): result is Err<E> => {
   return result && Boolean((result as Err<E>).error);
 };

--- a/test/e2e-test.ts
+++ b/test/e2e-test.ts
@@ -1,0 +1,78 @@
+import axios from 'axios';
+import { assert } from 'console';
+import EventSource from 'eventsource';
+
+const BASE_URL = process.argv[2] || 'http://localhost:8000/api/v1';
+
+const sleep = (seconds: number) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));
+
+const image1 = 'https://gifs.com/image1';
+const image2 = 'https://gifs.com/image2';
+
+const player1 = axios.create({
+  baseURL: BASE_URL,
+});
+const player2 = axios.create({
+  baseURL: BASE_URL,
+});
+
+(async function runTest() {
+  console.log(`Running E2E test against ${BASE_URL}...`);
+  console.log('The test will take approx 1 minute to finish');
+
+  await sleep(2);
+
+  try {
+    const collectedEvents: { event: string; data: any }[] = [];
+    const {
+      data: { code },
+    } = await player1.post('/games', {
+      players: 2,
+      rounds: 1,
+    });
+
+    const events = new EventSource(`${BASE_URL}/games/${code}/events`);
+    events.addEventListener('message', (e: any) => {
+      const event = JSON.parse(e.data);
+
+      if (event?.data?.error) {
+        console.error(event);
+        process.exit(1);
+      } else {
+        console.debug(JSON.stringify(event, null, 2));
+      }
+      collectedEvents.push(event);
+    });
+
+    const { data: p1 } = await player1.post(`/games/${code}/join`, { name: 'P1' });
+    await player1.post(`/games/${code}/ready`, { player: p1.id });
+    const { data: p2 } = await player2.post(`/games/${code}/join`, { name: 'P2' });
+    await player2.post(`/games/${code}/ready`, { player: p2.id });
+
+    await sleep(1);
+
+    await player2.post(`/games/${code}/rounds/1/images`, { player: p2.id, url: image2 });
+    const { data: game } = await player1.post(`/games/${code}/rounds/1/images`, { player: p1.id, url: image1 });
+
+    const image1Id = game.rounds[0].images.find((image: any) => image.url === image1).id;
+    const image2Id = game.rounds[0].images.find((image: any) => image.url === image2).id;
+
+    // Await presentation
+    await sleep(21);
+
+    await player1.post(`games/${code}/rounds/1/vote`, { player: p1.id, image: image2Id });
+    await player2.post(`games/${code}/rounds/1/vote`, { player: p2.id, image: image1Id });
+
+    // Await round winner presentation
+    await sleep(11);
+
+    const finalEvent = collectedEvents[collectedEvents.length - 1];
+
+    assert(finalEvent.data.status === 'FINISHED');
+
+    process.exit(0);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/test/e2e-test.ts
+++ b/test/e2e-test.ts
@@ -2,27 +2,27 @@ import axios from 'axios';
 import { assert } from 'console';
 import EventSource from 'eventsource';
 
-const BASE_URL = process.argv[2] || 'http://localhost:8000/api/v1';
+const BASE_URL = process.env.APP_URL || 'http://localhost:8000/api/v1';
 
 const sleep = (seconds: number) => new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 
 const image1 = 'https://gifs.com/image1';
 const image2 = 'https://gifs.com/image2';
 
-const player1 = axios.create({
-  baseURL: BASE_URL,
-});
-const player2 = axios.create({
-  baseURL: BASE_URL,
-});
-
 (async function runTest() {
   console.log(`Running E2E test against ${BASE_URL}...`);
-  console.log('The test will take approx 1 minute to finish');
+  console.log('A successful test will take approx 1 minute to finish');
 
-  await sleep(2);
+  await sleep(3);
 
   try {
+    const player1 = axios.create({
+      baseURL: BASE_URL,
+    });
+    const player2 = axios.create({
+      baseURL: BASE_URL,
+    });
+
     const collectedEvents: { event: string; data: any }[] = [];
     const {
       data: { code },
@@ -35,7 +35,7 @@ const player2 = axios.create({
     events.addEventListener('message', (e: any) => {
       const event = JSON.parse(e.data);
 
-      if (event?.data?.error) {
+      if (event.data?.error || (event.data && Object.keys(event.data).length === 0)) {
         console.error(event);
         process.exit(1);
       } else {


### PR DESCRIPTION
Use Redis for game state management instead of in-memory. This will allow us to scale the server to multiple instances and keep the game state in sync across all clients.

If no REDIS_URL is provided we fallback to using an in-memory database and a standard EventEmitter for pubsub.

This PR also adds an E2E test which relies on docker being installed:

`npm run test:e2e`